### PR TITLE
Use monit to restart processes in the manager script

### DIFF
--- a/lib/foreman/data/templates/manager.sh.erb
+++ b/lib/foreman/data/templates/manager.sh.erb
@@ -4,7 +4,7 @@ function start() {
 <% engine.each_process do |name, process| -%>
 <% 1.upto(engine.formation[name]) do |num| -%>
 <% port = engine.port_for(process, num) -%>
-    sudo monit start <%= name %>-<%= num %>
+    sudo monit start <%= process_identifier(name, num) %>
 <% end -%>
 <% end -%>
 }
@@ -12,7 +12,7 @@ function start() {
 function stop() {
 <% engine.each_process do |name, process| -%>
 <% 1.upto(engine.formation[name]) do |num| -%>
-    sudo monit stop <%= name %>-<%= num %>
+    sudo monit stop <%= process_identifier(name, num) %>
 <% end -%>
 <% end -%>
 }
@@ -21,7 +21,7 @@ function restart() {
 <% engine.each_process do |name, process| -%>
 <% 1.upto(engine.formation[name]) do |num| -%>
 <% port = engine.port_for(process, num) -%>
-    sudo monit restart <%= name %>-<%= num %>
+    sudo monit restart <%= process_identifier(name, num) %>
 <% end -%>
 <% end -%>
 }

--- a/lib/foreman/data/templates/manager.sh.erb
+++ b/lib/foreman/data/templates/manager.sh.erb
@@ -4,7 +4,7 @@ function start() {
 <% engine.each_process do |name, process| -%>
 <% 1.upto(engine.formation[name]) do |num| -%>
 <% port = engine.port_for(process, num) -%>
-    <%= start_command(port, name, num) %>
+    sudo monit start <%= name %>-<%= num %>
 <% end -%>
 <% end -%>
 }
@@ -12,7 +12,7 @@ function start() {
 function stop() {
 <% engine.each_process do |name, process| -%>
 <% 1.upto(engine.formation[name]) do |num| -%>
-    <%= stop_command(name, num) %>
+    sudo monit stop <%= name %>-<%= num %>
 <% end -%>
 <% end -%>
 }
@@ -21,8 +21,7 @@ function restart() {
 <% engine.each_process do |name, process| -%>
 <% 1.upto(engine.formation[name]) do |num| -%>
 <% port = engine.port_for(process, num) -%>
-    <%= stop_command(name, num) %>
-    <%= start_command(port, name, num) %>
+    sudo monit restart <%= name %>-<%= num %>
 <% end -%>
 <% end -%>
 }

--- a/lib/foreman/export/monit.rb
+++ b/lib/foreman/export/monit.rb
@@ -69,6 +69,10 @@ module Foreman
         @env_options.split(",").map{|option| option.split(":")[0].strip.upcase + "=" + option.split(":").map(&:strip)[1..-1].join(":") }.join(" ") if @env_options
       end
 
+      def process_identifier(process_name, num)
+        "#{app}-#{process_name}-#{num}"
+      end
+
       def start_command(port, process_name, num)
         "#{@shell} -c 'PORT=#{port} PID_FILE=#{pid_file_for(process_name, num)} LOG_FILE=#{log_file_for(process_name, num)} #{wrapper_path_for(process_name)} start'"
       end

--- a/lib/foreman/export/monit.rb
+++ b/lib/foreman/export/monit.rb
@@ -66,7 +66,7 @@ module Foreman
       end
 
       def expanded_options
-        @env_options.split(",").map{|option| option.split(":")[0].strip.upcase + "=" + option.split(":").map(&:strip)[1..-1].join(":") }.join(" ")
+        @env_options.split(",").map{|option| option.split(":")[0].strip.upcase + "=" + option.split(":").map(&:strip)[1..-1].join(":") }.join(" ") if @env_options
       end
 
       def start_command(port, process_name, num)


### PR DESCRIPTION
Processes aren't starting when the shell scripts run via capistrano because the scripts are only forking and not being daemonized. This means they get killed as soon as the shell is gone. Using monit to perform the start/stop fixes this.

This can be reproduced by turning off monit and running the cap monit:foreman_restart_processes task. The processes will stop but never actually start up again. It only looked like it was working previously because monit would detect the processes were gone and automatically restart them (after some delay).

@chmurph2
